### PR TITLE
Fixed DOMNodes iteration. Closes #4 #12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "dragscroll",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "homepage": "https://github.com/asvd/dragscroll",
   "authors": [
     "Dmitry Prokashev <heliosframework@gmail.com>"

--- a/dragscroll.js
+++ b/dragscroll.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview dragscroll - scroll area by dragging
- * @version 0.0.5
+ * @version 0.0.6
  * 
  * @license MIT, see http://github.com/asvd/intence
  * @copyright 2015 asvd <heliosframework@gmail.com> 
@@ -36,7 +36,7 @@
             _window[removeEventListener](mousemove, el.mm, 0);
         }
 
-        dragged = _document.getElementsByClassName('dragscroll');
+        dragged = [].slice.call(_document.getElementsByClassName('dragscroll'));
         for (i = 0; i < dragged.length;) {
             (function(el, lastClientX, lastClientY, pushed, scroller, cont){
                 (cont = el[container] || el)[addEventListener](


### PR DESCRIPTION
Hi,

I've decided to use `[].slice.call` because I saw usage of `.addEventListener()` at sources so due to [browsers support](http://caniuse.com/#feat=addeventlistener) it won't work at IE8 anyway.