### PR TITLE
Disable drag on INPUT SELECT and TEXTAREA

### DIFF
--- a/dragscroll.js
+++ b/dragscroll.js
@@ -43,6 +43,13 @@
                 (cont = el.container || el)[addEventListener](
                     mousedown,
                     cont.md = function(e) {
+                        if (e.target.tagName === "SELECT"
+                          || e.target.tagName === "INPUT"
+                          || e.target.tagName === "TEXTAREA"
+                        ) {                      
+                            return true
+                        }
+
                         if (!el.hasAttribute('nochilddrag') ||
                             _document.elementFromPoint(
                                 e.pageX, e.pageY


### PR DESCRIPTION
Some tag like INPUT, SELECT and TEXTAREA should not be draggable. Tested on my POS Project. (Chrome on XP POS Edition in NEC POS)