### PR TITLE
Add disabledrag attr to pinpoint disable dragging.

### DIFF
--- a/dragscroll.js
+++ b/dragscroll.js
@@ -43,6 +43,12 @@
                 (cont = el.container || el)[addEventListener](
                     mousedown,
                     cont.md = function(e) {
+                        if (e.target.hasAttribute('disabledrag') 
+                            || e.target.closest('[disabledrag]')
+                        ) {                      
+                            return true
+                        }
+
                         if (!el.hasAttribute('nochilddrag') ||
                             _document.elementFromPoint(
                                 e.pageX, e.pageY


### PR DESCRIPTION
I used nochilddrag but it not work when I press child element. I look into code that found you don't use closest so I add new attr. I think if I edit nochilddrag will cause side effect to another project so this new attr is solution.