### PR TITLE
update nodrag

### DIFF
--- a/dragscroll.js
+++ b/dragscroll.js
@@ -43,6 +43,16 @@
                 (cont = el.container || el)[addEventListener](
                     mousedown,
                     cont.md = function(e) {
+                        var noDrag = false
+                        for (let i = 0; i < e.path.length; i++) {
+                          if (
+                            typeof e.path[i].hasAttribute === 'function' &&
+                            e.path[i].hasAttribute('nodrag')
+                          ) {
+                            noDrag = true
+                            break
+                          }
+                        }
                         if (!el.hasAttribute('nochilddrag') ||
                             _document.elementFromPoint(
                                 e.pageX, e.pageY


### PR DESCRIPTION
Now you can add a nodrag attribute on an element that you want to no drag anymore.
It is more powerful that nochilddrag, for example when you use a library of virtual scroller that add a wrapper, in this case you can't drag anymore with nochilddrag; insteand with add no drag on element that you want to no drag anymore work fine