### PR TITLE
Fix intuitive propagation behavior

### DIFF
--- a/dragscroll.js
+++ b/dragscroll.js
@@ -21,7 +21,7 @@
     var mousemove = 'mousemove';
     var mouseup = 'mouseup';
     var mousedown = 'mousedown';
-    var mouseout = 'mouseout';
+    var mouseenter = 'mouseenter';
     var click = 'click';
     var EventListener = 'EventListener';
     var addEventListener = 'add'+EventListener;
@@ -38,7 +38,7 @@
             el[removeEventListener](click, el.mc, 0);
             _window[removeEventListener](mouseup, el.mu, 0);
             _window[removeEventListener](mousemove, el.mm, 0);
-            _document[removeEventListener](mouseout, el.mo, 0);
+            _document[removeEventListener](mouseenter, el.mo, 0);
         }
 
         // cloning into array since HTMLCollection is updated dynamically
@@ -75,7 +75,7 @@
                     mouseup, cont.mu = function() {pushed = 0;}, 0
                 );
                 _document[addEventListener](
-                  mouseout, cont.mo = function() {pushed = 0;}, 0
+                  mouseenter, cont.me = function(e) {if (!e.buttonsPressed) pushed = 0;}, 0
                 );
                 _window[addEventListener](
                     mousemove,

--- a/dragscroll.js
+++ b/dragscroll.js
@@ -68,6 +68,7 @@
                     if (moved) {
                       e.preventDefault();
                       e.stopPropagation();
+                      moved = 0; pushed = 0;
                     }
                   }, 1
                 );

--- a/dragscroll.js
+++ b/dragscroll.js
@@ -21,6 +21,7 @@
     var mousemove = 'mousemove';
     var mouseup = 'mouseup';
     var mousedown = 'mousedown';
+    var mouseout = 'mouseout';
     var click = 'click';
     var EventListener = 'EventListener';
     var addEventListener = 'add'+EventListener;
@@ -37,6 +38,7 @@
             el[removeEventListener](click, el.mc, 0);
             _window[removeEventListener](mouseup, el.mu, 0);
             _window[removeEventListener](mousemove, el.mm, 0);
+            _document[removeEventListener](mouseout, el.mo, 0);
         }
 
         // cloning into array since HTMLCollection is updated dynamically
@@ -72,7 +74,9 @@
                 _window[addEventListener](
                     mouseup, cont.mu = function() {pushed = 0;}, 0
                 );
-
+                _document[addEventListener](
+                  mouseout, cont.mo = function() {pushed = 0;}, 0
+                );
                 _window[addEventListener](
                     mousemove,
                     cont.mm = function(e) {

--- a/dragscroll.js
+++ b/dragscroll.js
@@ -38,7 +38,7 @@
             el[removeEventListener](click, el.mc, 0);
             _window[removeEventListener](mouseup, el.mu, 0);
             _window[removeEventListener](mousemove, el.mm, 0);
-            _document[removeEventListener](mouseenter, el.mo, 0);
+            _document[removeEventListener](mouseenter, el.me, 0);
         }
 
         // cloning into array since HTMLCollection is updated dynamically


### PR DESCRIPTION
- Add small threshold to begin dragging
- Don't propagate clicks to scrolled element after movement has reached threshold
  - Useful if you are scrolling something with lots of links or buttons in it
- Don't propagate `mousedown` events
  - Useful if you have `.dragscroll`s embedded in other `.dragscroll`s

These changes break current behavior, and add a few more bytes, but it makes the behavior a lot more intuitive to me. Creating the pull request in case it seems more intuitive to anyone else.