### PR TITLE
Add dragging class to wrap when drag is active

### DIFF
--- a/dragscroll.js
+++ b/dragscroll.js
@@ -65,6 +65,7 @@
                     mousemove,
                     cont.mm = function(e) {
                         if (pushed) {
+                            el.classList.add('dragging');
                             (scroller = el.scroller||el).scrollLeft -=
                                 newScrollX = (- lastClientX + (lastClientX=e.clientX));
                             scroller.scrollTop -=


### PR DESCRIPTION
This change will add a `dragging` class to the wrap. Now we have more control. Ex: unset pointer event for some child, like `a` tags